### PR TITLE
Fixes for writing xml

### DIFF
--- a/cytoscape-graphml.js
+++ b/cytoscape-graphml.js
@@ -48,23 +48,20 @@ module.exports = function (cy, $, options) {
   }
 
 
-  function parseNode(ele) {
-    var node = '<node id="' + ele.id() + '">';
+  function parseNode(ele, xml) {
+
+    var node = $('<node />', xml).attr( {id: ele.id() } ).appendTo(xml);
 
     var eleData = getEleData(ele);
     for (var key in eleData)
-      node += '<data type="' + eleData[key].attrType + '" key="' + key + '">' + eleData[key].value + '</data>';
-
+      $('<data />', node).attr({type: eleData[key].attrType, key: key}).text(eleData[key].value).appendTo(node);
 
     if (ele.isParent()) {
-      node += '<graph id="' + ele.id() + ':">';
+      var subgraph = $('<graph />', node).attr({id: ele.id() + ':'}).appendTo(node);
       ele.children().each(function (i, child) {
-        node += parseNode(child);
+	parseNode(child, subgraph);
       });
-      node += '</graph>'
     }
-
-    node += '</node>';
     return node;
   }
 
@@ -87,20 +84,16 @@ module.exports = function (cy, $, options) {
   var $graph = $xml.find("graph");
 
   cy.nodes().orphans().forEach(function (ele) {
-    $graph.append(parseNode(ele));
+    parseNode(ele, $graph);
   });
 
   cy.edges().forEach(function (ele) {
 
-    var edge = '<edge id="' + ele.id() + '" source="' + ele.source().id() + '"' + ' target="' + ele.target().id() + '" >';
-
+    var edge = $('<edge />', $graph).attr({id: ele.id(), source: ele.source().id(), target: ele.target().id()}).appendTo($graph);
+    
     var eleData = getEleData(ele);
     for (var key in eleData)
-      edge += '<data key="' + key + '">' + eleData[key] + '</data>';
-
-    edge += '</edge>';
-
-    $graph.append(edge);
+      $('<data />', edge).attr({key: key}).text(eleData[key].value).appendTo(edge);      
 
   });
 


### PR DESCRIPTION
Issue #6:
Switched from writing XML manually for nodes/edges to creating them with appropiate methods. This will fix problems associated with special characters (<>'"&).

Not tested on subgraphs

Fixed bug for edge attributes as well (issue #2)