### PR TITLE
Fixed 3 variable declaration

### DIFF
--- a/cytoscape-graphml.js
+++ b/cytoscape-graphml.js
@@ -138,10 +138,10 @@ module.exports = function (cy, $, options, cyGraphML) {
   }
 
   cy.batch(function () {
-    xml = $.parseXML(cyGraphML);
-    $xml = $(xml);
+    var xml = $.parseXML(cyGraphML);
+    var $xml = $(xml);
 
-    $graphs = $xml.find("graph").first();
+    var $graphs = $xml.find("graph").first();
 
     $graphs.each(function () {
       var $graph = $(this);


### PR DESCRIPTION
<a href="https://ibb.co/RjR0wK1"><img src="https://i.ibb.co/kmN8CTp/graphml-cytoscape.jpg" alt="graphml-cytoscape" border="0"></a>

In cytoscape-graphml.js, 3 variable (xml, $xml, $graphs) were not declared properly. 
This was causing error in Angular project.

It works when we use angular.json to import cytoscape js , cytoscape-graphml and Jquery but cause error if we import in component class.